### PR TITLE
add PHP 8.3 support and remove `beste/json`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php: ["8.1", "8.2"]
+        php: ["8.1", "8.2", "8.3"]
     name: PHP ${{ matrix.php }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,9 @@
         }
     ],
     "require": {
-        "php": "~8.1.0|~8.2.0",
+        "php": "~8.1.0|~8.2.0|~8.3.0",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "beste/json": "^1.2",
         "psr/http-client": "^1.0.1",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory": "^1.0.1",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -5,6 +5,7 @@ parameters:
 		- tests/
 
 	checkUninitializedProperties: true
+	checkGenericClassInNonGenericObjectType: false
 
 	ignoreErrors:
 		-

--- a/src/Api/HttpApiClient.php
+++ b/src/Api/HttpApiClient.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gamez\Mite\Api;
 
-use Beste\Json;
 use Gamez\Mite\Exception\ApiClientError;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -83,10 +82,8 @@ final class HttpApiClient implements ApiClient
 
         $body = null;
 
-        if (null !== $data) {
-            $body = JSON::encode($data);
-            \assert('' !== $body);
-
+        if ($data) {
+            $body = json_encode($data) ?: null;
             $headers['Content-Type'] = 'application/json';
         }
 

--- a/src/Exception/ApiClientError.php
+++ b/src/Exception/ApiClientError.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gamez\Mite\Exception;
 
-use Beste\Json;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -47,7 +46,7 @@ final class ApiClientError extends \RuntimeException implements MiteException
         $code = $response->getStatusCode();
 
         try {
-            $data = JSON::decode((string) $response->getBody(), true);
+            $data = json_decode((string) $response->getBody(), true, 512, \JSON_THROW_ON_ERROR);
         } catch (\Throwable $e) {
             $data = [];
         }

--- a/src/SimpleApi.php
+++ b/src/SimpleApi.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gamez\Mite;
 
-use Beste\Json;
 use Gamez\Mite\Api\ApiClient;
 
 final class SimpleApi
@@ -73,7 +72,7 @@ final class SimpleApi
     public function createCustomer(array $data): array
     {
         $response = $this->client->post('customers', ['customer' => $data]);
-        $data = JSON::decode((string) $response->getBody(), true);
+        $data = json_decode((string) $response->getBody(), true);
 
         return current($data);
     }
@@ -137,7 +136,7 @@ final class SimpleApi
     public function createProject(array $data): array
     {
         $response = $this->client->post('projects', ['project' => $data]);
-        $data = JSON::decode((string) $response->getBody(), true);
+        $data = json_decode((string) $response->getBody(), true);
 
         return current($data);
     }
@@ -201,7 +200,7 @@ final class SimpleApi
     public function createService(array $data): array
     {
         $response = $this->client->post('services', ['service' => $data]);
-        $data = JSON::decode((string) $response->getBody(), true);
+        $data = json_decode((string) $response->getBody(), true);
 
         return current($data);
     }
@@ -272,7 +271,7 @@ final class SimpleApi
     public function createTimeEntry(array $data): array
     {
         $response = $this->client->post('time_entries', ['time_entry' => $data]);
-        $data = JSON::decode((string) $response->getBody(), true);
+        $data = json_decode((string) $response->getBody(), true);
 
         return current($data);
     }
@@ -328,7 +327,7 @@ final class SimpleApi
     {
         $response = $this->client->get($endpoint, $params);
 
-        $data = JSON::decode((string) $response->getBody(), true);
+        $data = json_decode((string) $response->getBody(), true);
 
         return array_column($data, $column);
     }
@@ -343,7 +342,7 @@ final class SimpleApi
         $response = $this->client->get($endpoint);
 
         /** @var array<non-empty-string|mixed> $data */
-        $data = JSON::decode((string) $response->getBody(), true);
+        $data = json_decode((string) $response->getBody(), true);
 
         /** @var array<non-empty-string|mixed> $data */
         return current($data);

--- a/src/SimpleTracker.php
+++ b/src/SimpleTracker.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gamez\Mite;
 
-use Beste\Json;
 use Gamez\Mite\Api\ApiClient;
 
 final class SimpleTracker
@@ -25,7 +24,7 @@ final class SimpleTracker
     public function status(): array
     {
         $response = $this->client->get('tracker');
-        $data = JSON::decode((string) $response->getBody(), true);
+        $data = json_decode((string) $response->getBody(), true);
 
         return current($data);
     }
@@ -38,7 +37,7 @@ final class SimpleTracker
     public function start(int|string $id): array
     {
         $response = $this->client->patch("tracker/{$id}");
-        $data = JSON::decode((string) $response->getBody(), true);
+        $data = json_decode((string) $response->getBody(), true);
 
         return current($data);
     }
@@ -51,7 +50,7 @@ final class SimpleTracker
     public function stop(int|string $id): array
     {
         $response = $this->client->delete("tracker/{$id}");
-        $data = JSON::decode((string) $response->getBody(), true);
+        $data = json_decode((string) $response->getBody(), true);
 
         return current($data);
     }


### PR DESCRIPTION
Refs: https://github.com/jeromegamez/mite-php/issues/12

Well, here is what I did and what the current problem is.

The `beste/json` package is not PHP 8.3 ready yet but since it doesn't really do much I just replaced it with native `json_encode` and `json_decode` methods.

But there is also the issue, that Github CI doesn't work for PHP 8.3 yet because `beste/php-cs-fixer-config` is not yet PHP 8.3 ready. `php-cs-fixer` itself just recently released a 8.3 compatible version but the used dependency not yet.