### PR TITLE
PHP 8.4 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php: ["8.1", "8.2", "8.3"]
+        php: ["8.1", "8.2", "8.3", "8.4"]
     name: PHP ${{ matrix.php }}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 /vendor
 
 .env
-/.php-cs-fixer.php
-/.php-cs-fixer.cache
+/.pint.cache.json
 /.phpunit.result.cache
 /composer.lock
 /phpstan.neon

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-mbstring": "*",
         "beste/json": "^1.2",
@@ -28,9 +28,8 @@
         "psr/http-factory-implementation": "^1.0"
     },
     "require-dev": {
-        "beste/php-cs-fixer-config": "^2.4.1",
-        "friendsofphp/php-cs-fixer": "^3.52.1",
         "guzzlehttp/guzzle": "^7.8.1",
+        "laravel/pint": "^1.18",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/vcr-plugin": "^1.2.3",
         "phpstan/extension-installer": "^1.3.1",

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,15 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "final_class": true,
+        "no_unused_imports": true,
+        "php_unit_internal_class": true,
+        "php_unit_test_class_requires_covers": true,
+        "blank_line_before_statement": false,
+        "binary_operator_spaces": false,
+        "phpdoc_separation": false,
+        "phpdoc_align": false,
+        "modernize_strpos": true
+    },
+    "cache-file": ".pint.cache.json"
+}

--- a/src/Api/HttpApiClient.php
+++ b/src/Api/HttpApiClient.php
@@ -82,9 +82,9 @@ final class HttpApiClient implements ApiClient
 
         $body = null;
 
-        if (null !== $data) {
+        if ($data !== null) {
             $body = Json::encode($data);
-            \assert('' !== $body);
+            \assert($body !== '');
 
             $headers['Content-Type'] = 'application/json';
         }
@@ -97,7 +97,7 @@ final class HttpApiClient implements ApiClient
             throw ApiClientError::fromRequestAndReason($request, "Unable to send request to send {$method} request to {$endpoint}", $e);
         }
 
-        if (400 <= $response->getStatusCode()) {
+        if ($response->getStatusCode() >= 400) {
             throw ApiClientError::fromRequestAndResponse($request, $response);
         }
 
@@ -114,8 +114,8 @@ final class HttpApiClient implements ApiClient
     {
         $url = "https://{$this->apiHost}/{$endpoint}.json";
 
-        if (!empty($params)) {
-            $url .= '?' . http_build_query($params, '', '&', \PHP_QUERY_RFC3986);
+        if (! empty($params)) {
+            $url .= '?'.http_build_query($params, '', '&', \PHP_QUERY_RFC3986);
         }
 
         return $url;
@@ -131,7 +131,7 @@ final class HttpApiClient implements ApiClient
     {
         $request = $this->requestFactory->createRequest($method, $url);
 
-        if (null !== $body) {
+        if ($body !== null) {
             $request->getBody()->write($body);
         }
 

--- a/src/Api/HttpApiClientFactory.php
+++ b/src/Api/HttpApiClientFactory.php
@@ -13,6 +13,7 @@ use SensitiveParameter;
 final class HttpApiClientFactory implements ApiClientFactory
 {
     private RequestFactoryInterface $requestFactory;
+
     private ClientInterface $httpClient;
 
     public function __construct(

--- a/src/Exception/ApiClientError.php
+++ b/src/Exception/ApiClientError.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 final class ApiClientError extends \RuntimeException implements MiteException
 {
     private RequestInterface $request;
+
     private ?ResponseInterface $response;
 
     public function __construct(

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -36,7 +36,7 @@ abstract class IntegrationTestCase extends TestCase
 
         $throwIfNotAbleToReplay = $apiKey === '';
 
-        $apiClientFactory = new VCRApiClientFactory(__DIR__ . '/../fixtures/vcr', $throwIfNotAbleToReplay);
+        $apiClientFactory = new VCRApiClientFactory(__DIR__.'/../fixtures/vcr', $throwIfNotAbleToReplay);
 
         self::$apiClient = $apiClientFactory($accountName, $apiKey);
     }

--- a/tests/Support/AppendCallerHeaderPlugin.php
+++ b/tests/Support/AppendCallerHeaderPlugin.php
@@ -35,7 +35,7 @@ final class AppendCallerHeaderPlugin implements Plugin
             $function = $item['function'];
 
             if (str_contains($class, $this->namespace)) {
-                $method = $class . '::' . $function;
+                $method = $class.'::'.$function;
 
                 break;
             }
@@ -48,7 +48,7 @@ final class AppendCallerHeaderPlugin implements Plugin
         $request = $request->withAddedHeader($this->header, $method);
 
         return $next($request)->then(function (ResponseInterface $response) use ($method) {
-            if (!$response->hasHeader($this->header)) {
+            if (! $response->hasHeader($this->header)) {
                 $response = $response->withAddedHeader($this->header, $method);
             }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->safeLoad();


### PR DESCRIPTION
Please add support for PHP 8.4.

I have introduced Pint with a new `pint.json` config based on `laravel` preset and your previous `.php-cs-fixer.php`, as I found it easier to get running under PHP 8.4 and honestly don't know of anybody still using plain PHP-CS-Fixer. But feel free to revert that.